### PR TITLE
BUGFIX: unable to execute vcgencmd on 64-bit Raspbian

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ CPUVInf is capable of reading various system voltages and converting the output 
 Memory Split<br />
 CPUVInf can display the assigned RAM for the internal GPU and system RAM (usable RAM) in MB values.<br /><br /><br />
 <B>Installation<B><br /><br />
-1. Clone: `git clone https://github.com/tnyim/cpuvinf.git`<br />
-2. Make executable: `cd cpuvinf && chmod +x ./cpuvinf`<br />
-3. Move to system directory: `sudo mv ./cpuvinf /usr/bin`<br />
+1. Clone: <pre>git clone https://github.com/tnyim/cpuvinf.git</pre><br />
+2. Make executable: <pre>cd cpuvinf && chmod +x ./cpuvinf</pre><br />
+3. Move to system directory: <pre>sudo mv ./cpuvinf /usr/bin</pre><br />
 <br /><br />
 <B>Usage</B><br /><br />
 CPU & GPU Temperature<br />

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ CPUVInf is capable of reading various system voltages and converting the output 
 Memory Split<br />
 CPUVInf can display the assigned RAM for the internal GPU and system RAM (usable RAM) in MB values.<br /><br /><br />
 <B>Installation<B><br /><br />
-1. Clone: `git clone https://github.com/tnyim/cpuvinf.git`
-2. Make executable: `cd cpuvinf && chmod +x ./cpuvinf`
-3. Move to system directory: `sudo mv ./cpuvinf /usr/bin`
+1. Clone: `git clone https://github.com/tnyim/cpuvinf.git`<br />
+2. Make executable: `cd cpuvinf && chmod +x ./cpuvinf`<br />
+3. Move to system directory: `sudo mv ./cpuvinf /usr/bin`<br />
 <br /><br />
 <B>Usage</B><br /><br />
 CPU & GPU Temperature<br />

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# cpuvinf 1.2
+# cpuvinf 1.3
 CPUVInf - Raspberry Pi Diagnostics Tool<br /><br /><br />
-<B>What is CPUVINF?</B><br /><br />
+<B>What is CPUVInf?</B><br /><br />
 CPUVInf is a tiny, simple and useful diagnostics tool for the Raspberry Pi minicomputer series written purely in shell scripting language. It is compatible with all Raspberry Pi 1 and all Raspberry Pi 2 minicomputers and therefore with all available Linux based operating systems for the Raspberry Pi series. It started off as a small script to read CPU temperature and voltage but has become much more than that.<br /><br /><br />
 <B>Full list of compatible OS:</B>
 <ul>
@@ -20,6 +20,11 @@ System Voltages<br />
 CPUVInf is capable of reading various system voltages and converting the output into Volt values. Voltage types: core, SDRAM core, SDRAM I/O and SDRAM PHY voltages.<br /><br />
 Memory Split<br />
 CPUVInf can display the assigned RAM for the internal GPU and system RAM (usable RAM) in MB values.<br /><br /><br />
+<B>Installation<B><br /><br />
+1. Clone: `git clone https://github.com/tnyim/cpuvinf.git`
+2. Make executable: `cd cpuvinf && chmod +x ./cpuvinf`
+3. Move to system directory: `sudo mv ./cpuvinf /usr/bin`
+<br /><br />
 <B>Usage</B><br /><br />
 CPU & GPU Temperature<br />
 <pre>cpuvinf -t 

--- a/cpuvinf
+++ b/cpuvinf
@@ -1,19 +1,27 @@
-#!/bin/bash
+#!/bin/env bash
 
 ###################################################
-# CPUVInf 1.2 - Raspberry Pi Diagnostics Tool     #
-# Copyright© 2014 - 2017 by Hidden-Refuge         #
+# CPUVInf 1.3 - Raspberry Pi Diagnostics Tool     #
+# Copyright© 2014 - 2023 by Hidden-Refuge         #
 # License: GNU GPL 3                              #
 # https://www.gnu.org/licenses/gpl.html           #
 ###################################################
 # A TNY Network driven project                    #
 # Visit us at https://i.tny.im/                   #
-# Copyright© 2011 - 2017 by TNY Network           #
+# Copyright© 2011 - 2023 by TNY Network           #
 ###################################################
+
+# Test vcgencmd; depending on the configuraton, a 32-bit binary may be present
+# in /opt/vc/bin on a 64-bit system. An appropriate one is probably in /usr/bin.
+_vcgencmd=$( command -v vcgencmd )
+if [ -z "$_vcgencmd" ] || ! $_vcgencmd commands >/dev/null 2>&1; then
+  echo -e "\x1b[31mcpuvinf: error: unable to execute vcgencmd; please check your configuration\x1b[0m"
+  exit 1
+fi
 
 # Current CPU/GPU temperatures in Celsius and Fa-
 # renheit
-temp ()	{
+temp ()  {
    tempc=$( awk '{printf "%3.1f°C\n", $1/1000}' /sys/class/thermal/thermal_zone0/temp )
    tempf=$( awk '{printf "%3.1f°F\n", $1/1000*9/5+32}' /sys/class/thermal/thermal_zone0/temp )
    echo ""
@@ -25,12 +33,12 @@ temp ()	{
 }
 
 # CPU/GPU frequencies in MHz and CPU governor
-clock ()	{
+clock () {
    mintmp=$( cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_min_freq )
    maxtmp=$( cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq )
    curtmp=$( cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq )
    gov=$( cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor )
-   gputmp=$( /opt/vc/bin/vcgencmd measure_clock core | sed -r 's/^.{13}//' )
+   gputmp=$( $_vcgencmd measure_clock core | sed -r 's/^.{13}//' )
    minfreq=$( expr $mintmp / 1000 )
    maxfreq=$( expr $maxtmp / 1000 )
    curfreq=$( expr $curtmp / 1000 )
@@ -47,11 +55,11 @@ clock ()	{
 }
 
 # System voltages in Volt (Core, SDRAM, etc...)
-volt ()	{
-   vcore=$( /opt/vc/bin/vcgencmd measure_volts core | sed 's/volt=//' )
-   vsdramcore=$( /opt/vc/bin/vcgencmd measure_volts sdram_c | sed 's/volt=//' )
-   vsdramio=$( /opt/vc/bin/vcgencmd measure_volts sdram_i | sed 's/volt=//' )
-   vsdramphy=$( /opt/vc/bin/vcgencmd measure_volts sdram_p | sed 's/volt=//' )
+volt ()  {
+   vcore=$( $_vcgencmd measure_volts core | sed 's/volt=//' )
+   vsdramcore=$( $_vcgencmd measure_volts sdram_c | sed 's/volt=//' )
+   vsdramio=$( $_vcgencmd measure_volts sdram_i | sed 's/volt=//' )
+   vsdramphy=$( $_vcgencmd measure_volts sdram_p | sed 's/volt=//' )
    echo ""
    echo "System Voltages"
    echo ""
@@ -64,9 +72,9 @@ volt ()	{
 
 # Memorysplit for system usable RAM and GPU
 # usable RAM
-memorysplit ()	{
-   systemram=$( /opt/vc/bin/vcgencmd get_mem arm | sed -r 's/^.{4}//' )
-   gpuram=$( /opt/vc/bin/vcgencmd get_mem gpu | sed -r 's/^.{4}//')
+memorysplit () {
+   systemram=$( $_vcgencmd get_mem arm | sed -r 's/^.{4}//' )
+   gpuram=$( $_vcgencmd get_mem gpu | sed -r 's/^.{4}//')
    echo ""
    echo "Memorysplit"
    echo ""
@@ -76,52 +84,52 @@ memorysplit ()	{
 }
 
 # Help
-help ()	{
-	echo ""
-	echo "cpuvinf 1.2 by Hidden Refuge <me at hiddenrefuge dot eu dot org>"
-	echo ""
+help ()  {
+   echo ""
+   echo "cpuvinf 1.3 by Hidden Refuge <me at hiddenrefuge dot eu dot org>"
+   echo ""
     echo "Usage: cpuvinf <option>"
-	echo ""
-	echo "Available options:"
-	echo "-t, --temperature	Displays CPU/GPU temperature in °C/°F."
-	echo "-c, --clocks		Displays CPU/GPU clocks in MHz and CPU governor."
-	echo "-v, --voltages		Displays voltages of the core and SDRAM."
-	echo "-m, --memory		Displays the assigned memory amount for the GPU and the system."
-	echo "-a, --all		Displays all the things above at once."
-	echo ""
-	echo "Unfortunately CPUVInf has no man page :("
-	echo ""
+   echo ""
+   echo "Available options:"
+   echo "-t, --temperature Displays CPU/GPU temperature in °C/°F."
+   echo "-c, --clocks      Displays CPU/GPU clocks in MHz and CPU governor."
+   echo "-v, --voltages    Displays voltages of the core and SDRAM."
+   echo "-m, --memory      Displays the assigned memory amount for the GPU and the system."
+   echo "-a, --all      Displays all the things above at once."
+   echo ""
+   echo "Unfortunately CPUVInf has no man page :("
+   echo ""
 }
 
 # Option selection (short and long parameters)
 case $1 in
     '-t')
-       	temp;;
-	'--temperature')
-		temp;;
-	'-c')
-		clock;;
-	'--clocks')
-		clock;;
+         temp;;
+   '--temperature')
+      temp;;
+   '-c')
+      clock;;
+   '--clocks')
+      clock;;
     '-v')
         volt;;
-	'--voltages')
-		volt;;
-	'-m')
-		memorysplit;;
-	'--memory')
-		memorysplit;;
-	'-a')
-		temp; clock; volt; memorysplit;;
-	'--all')
-		temp; clock; volt; memorysplit;;
-	'-h')
-		help;;
+   '--voltages')
+      volt;;
+   '-m')
+      memorysplit;;
+   '--memory')
+      memorysplit;;
+   '-a')
+      temp; clock; volt; memorysplit;;
+   '--all')
+      temp; clock; volt; memorysplit;;
+   '-h')
+      help;;
     '--help')
-		help;;
-	*)
-		echo ""
-		echo "cpuvinf: Empty or invalid option!"
-		echo "Try 'cpuvinf -h' or 'cpuvinf --help' for more information."
-		echo "";;
+      help;;
+   *)
+      echo ""
+      echo "cpuvinf: Empty or invalid option!"
+      echo "Try 'cpuvinf -h' or 'cpuvinf --help' for more information."
+      echo "";;
 esac

--- a/cpuvinf
+++ b/cpuvinf
@@ -15,13 +15,13 @@
 # in /opt/vc/bin on a 64-bit system. An appropriate one is probably in /usr/bin.
 _vcgencmd=$( command -v vcgencmd )
 if [ -z "$_vcgencmd" ] || ! $_vcgencmd commands >/dev/null 2>&1; then
-  echo -e "\x1b[31mcpuvinf: error: unable to execute vcgencmd; please check your configuration\x1b[0m"
-  exit 1
+   echo -e "\x1b[31mcpuvinf: error: unable to execute vcgencmd; please check your configuration\x1b[0m"
+   exit 1
 fi
 
 # Current CPU/GPU temperatures in Celsius and Fa-
 # renheit
-temp ()  {
+temp ()	{
    tempc=$( awk '{printf "%3.1f°C\n", $1/1000}' /sys/class/thermal/thermal_zone0/temp )
    tempf=$( awk '{printf "%3.1f°F\n", $1/1000*9/5+32}' /sys/class/thermal/thermal_zone0/temp )
    echo ""
@@ -55,7 +55,7 @@ clock () {
 }
 
 # System voltages in Volt (Core, SDRAM, etc...)
-volt ()  {
+volt () {
    vcore=$( $_vcgencmd measure_volts core | sed 's/volt=//' )
    vsdramcore=$( $_vcgencmd measure_volts sdram_c | sed 's/volt=//' )
    vsdramio=$( $_vcgencmd measure_volts sdram_i | sed 's/volt=//' )
@@ -72,7 +72,7 @@ volt ()  {
 
 # Memorysplit for system usable RAM and GPU
 # usable RAM
-memorysplit () {
+memorysplit ()	{
    systemram=$( $_vcgencmd get_mem arm | sed -r 's/^.{4}//' )
    gpuram=$( $_vcgencmd get_mem gpu | sed -r 's/^.{4}//')
    echo ""
@@ -84,52 +84,52 @@ memorysplit () {
 }
 
 # Help
-help ()  {
-   echo ""
-   echo "cpuvinf 1.3 by Hidden Refuge <me at hiddenrefuge dot eu dot org>"
-   echo ""
-    echo "Usage: cpuvinf <option>"
-   echo ""
-   echo "Available options:"
-   echo "-t, --temperature Displays CPU/GPU temperature in °C/°F."
-   echo "-c, --clocks      Displays CPU/GPU clocks in MHz and CPU governor."
-   echo "-v, --voltages    Displays voltages of the core and SDRAM."
-   echo "-m, --memory      Displays the assigned memory amount for the GPU and the system."
-   echo "-a, --all      Displays all the things above at once."
-   echo ""
-   echo "Unfortunately CPUVInf has no man page :("
-   echo ""
+help ()	{
+	echo ""
+	echo "cpuvinf 1.3 by Hidden Refuge <me at hiddenrefuge dot eu dot org>"
+	echo ""
+   echo "Usage: cpuvinf <option>"
+	echo ""
+	echo "Available options:"
+	echo "-t, --temperature	Displays CPU/GPU temperature in °C/°F."
+	echo "-c, --clocks		Displays CPU/GPU clocks in MHz and CPU governor."
+	echo "-v, --voltages		Displays voltages of the core and SDRAM."
+	echo "-m, --memory		Displays the assigned memory amount for the GPU and the system."
+	echo "-a, --all		Displays all the things above at once."
+	echo ""
+	echo "Unfortunately CPUVInf has no man page :("
+	echo ""
 }
 
 # Option selection (short and long parameters)
 case $1 in
     '-t')
-         temp;;
-   '--temperature')
-      temp;;
-   '-c')
-      clock;;
-   '--clocks')
-      clock;;
+       	temp;;
+	'--temperature')
+		temp;;
+	'-c')
+		clock;;
+	'--clocks')
+		clock;;
     '-v')
         volt;;
-   '--voltages')
-      volt;;
-   '-m')
-      memorysplit;;
-   '--memory')
-      memorysplit;;
-   '-a')
-      temp; clock; volt; memorysplit;;
-   '--all')
-      temp; clock; volt; memorysplit;;
-   '-h')
-      help;;
+	'--voltages')
+		volt;;
+	'-m')
+		memorysplit;;
+	'--memory')
+		memorysplit;;
+	'-a')
+		temp; clock; volt; memorysplit;;
+	'--all')
+		temp; clock; volt; memorysplit;;
+	'-h')
+		help;;
     '--help')
-      help;;
-   *)
-      echo ""
-      echo "cpuvinf: Empty or invalid option!"
-      echo "Try 'cpuvinf -h' or 'cpuvinf --help' for more information."
-      echo "";;
+		help;;
+	*)
+		echo ""
+		echo "cpuvinf: Empty or invalid option!"
+		echo "Try 'cpuvinf -h' or 'cpuvinf --help' for more information."
+		echo "";;
 esac


### PR DESCRIPTION
On an RPi 4B running Raspbian (_6.1.57-v8+ #1688 SMP PREEMPT Thu Oct 12 15:14:26 BST 2023 aarch64 GNU/Linux_), I tried your script, and got errors like this:

```
/opt/vc/bin/vcgencmd: cannot execute, missing required file
```

Eventually, I figured out that the `vcgencmd` in `/opt/vc/bin` is a 32-bit executable, and this is a 64-bit platform... so, I tried `which vcgencmd` and found one in `/usr/bin`.

I modified the script to use `command -v` to locate the first vcgencmd in the $PATH, and use that instead. Now it works fine. I have no idea why there are two copies, or why they are in different locations. I ran repair on Raspberry Pi packages and that didn't resolve it.

I also took the liberty of bumping the version # for you and updating the copyright.

Thanks for the script. Cheers